### PR TITLE
Adiciona endpoint /home à aplicação

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,1 +1,1 @@
-web: ruby server.rb
+web: bundle && bundle exec puma -p 3000

--- a/README.md
+++ b/README.md
@@ -49,3 +49,10 @@ GET '/tests'
 ```
 - **Status**: 200 (OK)
 - **Corpo da resposta**: Arquivo JSON com os resultados dos exames cadastrados na plataforma
+
+### GET /home
+```bash
+http://localhost:3000/home
+```
+- **Status**: 200 (OK)
+- **Corpo da resposta**: Página web que exibe os resultados de `GET /tests` em formato de tabela dentro de uma página reativa, renderizando 100 conteúdos por vez.

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,3 @@
+require_relative './server'
+
+run Sinatra::Application

--- a/public/index.html
+++ b/public/index.html
@@ -7,18 +7,18 @@
     <title>Rebase Labs</title>
 </head>
 <body>
-    
     <section id="test-results">
         <h2>Resultados dos Exames</h2>
-        <table id="test-results-table">
-            <thead>
-                <tr id="table-headers">
-                </tr>
-            </thead>
-            <tbody id="tbody">
-            </tbody>
-        </table>
-        <br>
+        <div class="table-div">
+            <table id="test-results-table">
+                <thead>
+                    <tr id="table-headers">
+                    </tr>
+                </thead>
+                <tbody id="tbody">
+                </tbody>
+            </table>
+        </div>
         <div id="pagination"></div>
     </section>
     <script src="main.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -3,22 +3,24 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="/style.css">
     <title>Rebase Labs</title>
 </head>
 <body>
     
     <section id="test-results">
         <h2>Resultados dos Exames</h2>
-        <table>
+        <table id="test-results-table">
             <thead>
                 <tr id="table-headers">
                 </tr>
             </thead>
-            <tbody>
+            <tbody id="tbody">
             </tbody>
         </table>
+        <br>
+        <div id="pagination"></div>
     </section>
-    <script src="main.js" defer></script>
+    <script src="main.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="style.css">
+    <title>Rebase Labs</title>
+</head>
+<body>
+    
+    <section id="test-results">
+        <h2>Resultados dos Exames</h2>
+        <table>
+            <thead>
+                <tr id="table-headers">
+                </tr>
+            </thead>
+            <tbody>
+            </tbody>
+        </table>
+    </section>
+    <script src="main.js" defer></script>
+</body>
+</html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,31 +1,62 @@
-const table_data = new DocumentFragment(); // o que é DocumentFragment?
-const table_headers = new DocumentFragment();
 const tests_url = 'http://localhost:3000/tests'
 
-fetch(tests_url).
-  then((response) => response.json()). //essa linha converte para JSON? Ela faz um JSON.parse?
-  then((data) => {
-    Object.keys(data[0]).forEach(key => {
-      const th = document.createElement('th');
-      th.textContent = `${key}`;
-      th.classList = 'table-header';
-      table_headers.appendChild(th);
-    });
+fetch(tests_url)
+  .then((response) => response.json())
+  .then((data) => {
+    const table = document.getElementById('tbody')
+    const pagination = document.getElementById('pagination');
+    const itemsPerPage = 100;
+    let currentPage = 0;
 
-    data.forEach(function(test) {
-      const tr = document.createElement('tr');
-      Object.values(test).forEach(value => {
-        const td = document.createElement('td');
-        td.textContent = `${value}`;
-        td.classList = 'table-cell'
-        tr.appendChild(td);
+    function displayData(data, page) {
+      table.innerHTML = '';
+      const startIndex = page * itemsPerPage;
+      const endIndex = startIndex + itemsPerPage;
+      const pageData = data.slice(startIndex, endIndex);
+
+      pageData.forEach(test => {
+        const tr = document.createElement('tr');
+        Object.values(test).forEach(value => {
+          const td = document.createElement('td');
+          td.textContent = `${value}`;
+          td.classList.add('table-cell');
+          tr.appendChild(td);
+        })
+        table.appendChild(tr);
       });
-      table_data.appendChild(tr);
-})
-  }).
-  then(() => {
-    document.querySelector('#table-headers').appendChild(table_headers)
-    document.querySelector('tbody').appendChild(table_data)
-  }).catch(function(error) {
-    console.log(error);
-  })
+    };
+
+    function setupPagination(data) {
+      const pageCount = Math.ceil(data.length / itemsPerPage);
+
+      for (let index = 0; index < pageCount; index++) {
+        const button = document.createElement('button');
+        button.textContent = index + 1;
+        button.classList.add('btn')
+        button.addEventListener('click', () => {
+          currentPage = index;
+          displayData(data, currentPage);
+          window.scrollTo(0, 0);
+        });
+        pagination.appendChild(button);
+      }
+    };
+
+    function setupTableHeaders(data) {
+      const table_headers = new DocumentFragment();
+
+      Object.keys(data[0]).forEach(key => {
+        const th = document.createElement('th');
+        th.textContent = `${key}`;
+        th.classList.add('table-header');
+        table_headers.appendChild(th);
+      });
+
+      document.querySelector('#table-headers').appendChild(table_headers);
+    };
+
+    console.log(data);
+    setupTableHeaders(data);
+    displayData(data, currentPage);
+    setupPagination(data);
+  });

--- a/public/main.js
+++ b/public/main.js
@@ -1,31 +1,61 @@
-const table_data = new DocumentFragment(); // o que é DocumentFragment?
-const table_headers = new DocumentFragment();
 const tests_url = 'http://localhost:3000/tests'
 
-fetch(tests_url).
-  then((response) => response.json()). //essa linha converte para JSON? Ela faz um JSON.parse?
-  then((data) => {
-    Object.keys(data[0]).forEach(key => {
-      const th = document.createElement('th');
-      th.textContent = `${key}`;
-      th.classList = 'table-header';
-      table_headers.appendChild(th);
-    });
+fetch(tests_url)
+  .then((response) => response.json())
+  .then((data) => {
+    const table = document.getElementById('tbody')
+    const pagination = document.getElementById('pagination');
+    const itemsPerPage = 100;
+    let currentPage = 0;
 
-    data.forEach(function(test) {
-      const tr = document.createElement('tr');
-      Object.values(test).forEach(value => {
-        const td = document.createElement('td');
-        td.textContent = `${value}`;
-        td.classList = 'table-cell'
-        tr.appendChild(td);
+    function displayData(data, page) {
+      table.innerHTML = '';
+      const startIndex = page * itemsPerPage;
+      const endIndex = startIndex + itemsPerPage;
+      const pageData = data.slice(startIndex, endIndex);
+
+      pageData.forEach(test => {
+        const tr = document.createElement('tr');
+        Object.values(test).forEach(value => {
+          const td = document.createElement('td');
+          td.textContent = `${value}`;
+          td.classList.add('table-cell');
+          tr.appendChild(td);
+        })
+        table.appendChild(tr);
       });
-      table_data.appendChild(tr);
-})
-  }).
-  then(() => {
-    document.querySelector('#table-headers').appendChild(table_headers)
-    document.querySelector('tbody').appendChild(table_data)
-  }).catch(function(error) {
-    console.log(error);
-  })
+    };
+
+    function setupPagination(data) {
+      const pageCount = Math.ceil(data.length / itemsPerPage);
+
+      for (let index = 0; index < pageCount; index++) {
+        const button = document.createElement('button');
+        button.textContent = index + 1;
+        button.classList.add('btn')
+        button.addEventListener('click', () => {
+          currentPage = index;
+          displayData(data, currentPage);
+        });
+        pagination.appendChild(button);
+      }
+    };
+
+    function setupTableHeaders(data) {
+      const table_headers = new DocumentFragment();
+
+      Object.keys(data[0]).forEach(key => {
+        const th = document.createElement('th');
+        th.textContent = `${key}`;
+        th.classList.add('table-header');
+        table_headers.appendChild(th);
+      });
+
+      document.querySelector('#table-headers').appendChild(table_headers);
+    };
+
+    console.log(data);
+    setupTableHeaders(data);
+    displayData(data, currentPage);
+    setupPagination(data);
+  });

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,31 @@
+const table_data = new DocumentFragment(); // o que é DocumentFragment?
+const table_headers = new DocumentFragment();
+const tests_url = 'http://localhost:3000/tests'
+
+fetch(tests_url).
+  then((response) => response.json()). //essa linha converte para JSON? Ela faz um JSON.parse?
+  then((data) => {
+    Object.keys(data[0]).forEach(key => {
+      const th = document.createElement('th');
+      th.textContent = `${key}`;
+      th.classList = 'table-header';
+      table_headers.appendChild(th);
+    });
+
+    data.forEach(function(test) {
+      const tr = document.createElement('tr');
+      Object.values(test).forEach(value => {
+        const td = document.createElement('td');
+        td.textContent = `${value}`;
+        td.classList = 'table-cell'
+        tr.appendChild(td);
+      });
+      table_data.appendChild(tr);
+})
+  }).
+  then(() => {
+    document.querySelector('#table-headers').appendChild(table_headers)
+    document.querySelector('tbody').appendChild(table_data)
+  }).catch(function(error) {
+    console.log(error);
+  })

--- a/public/main.js
+++ b/public/main.js
@@ -47,15 +47,16 @@ fetch(tests_url)
 
       Object.keys(data[0]).forEach(key => {
         const th = document.createElement('th');
-        th.textContent = `${key}`;
-        th.classList.add('table-header');
+        const div = document.createElement('div')
+        div.textContent = `${key}`;
+        div.classList.add('table-header');
+        th.appendChild(div);
         table_headers.appendChild(th);
       });
 
       document.querySelector('#table-headers').appendChild(table_headers);
     };
 
-    console.log(data);
     setupTableHeaders(data);
     displayData(data, currentPage);
     setupPagination(data);

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,27 @@
+body {
+    background-color: #111
+}
+
+h2 {
+    color: white;
+    margin: 0 auto 1rem auto;
+    text-align: center;
+}
+
+table {
+    width: 80%;
+    margin: auto;
+}
+
+table, th, td {
+    border: 1px solid #DDD;
+    border-collapse: collapse;
+}
+
+.table-cell, .table-header {
+    color: #DDD;
+}
+
+.table-header {
+    text-transform: capitalize;
+}

--- a/public/style.css
+++ b/public/style.css
@@ -1,28 +1,54 @@
 body {
     background-color: #111;
-    font-family: Arial, Helvetica, sans-serif;
+    font-family: Helvetica, sans-serif;
 }
 
 table, td, th {
     border-collapse: collapse;
-    border: 1px solid #DDD;
     color: #DDD;
     text-align: center;
 }
 
 table {
+    border: 1px solid #DDD;
     width: 90vw; 
-    margin: auto; 
+    white-space: nowrap;
 }
 
-th {
+.table-div {
+    margin-bottom: 1rem;
+    overflow-x: scroll;
+    overflow-y: scroll;
+    max-width: 90vw;
+    max-height: 80vh;
+    margin: 0 auto 1rem auto;
+}
+
+td, th {
+    border-bottom: 1px solid #DDD;
+    padding: 1rem;
+}
+
+.table-header {
     text-transform: capitalize;
+    top: 0;
+    background-color: #111;
+}
+
+tr:nth-child(even) {
+    background-color: #333;
+}
+
+tr:hover {
+    background-color: blueviolet;
+    color: #111;
 }
 
 h2 {
     color: white;
-    margin: 0 auto 1rem auto;
+    margin: 0 auto 2rem auto;
     text-align: center;
+    font-size: 2rem;
 }
 
 #pagination {
@@ -40,4 +66,14 @@ h2 {
     min-width: 2rem;
     max-width: 2rem;
     border-radius: 4px;
+}
+
+.search-field {
+    margin-bottom: 1rem;
+    text-align: center;
+}
+
+input {
+    width: 20%;
+    text-align: center;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -1,5 +1,22 @@
 body {
-    background-color: #111
+    background-color: #111;
+    font-family: Arial, Helvetica, sans-serif;
+}
+
+table, td, th {
+    border-collapse: collapse;
+    border: 1px solid #DDD;
+    color: #DDD;
+    text-align: center;
+}
+
+table {
+    width: 90vw; 
+    margin: auto; 
+}
+
+th {
+    text-transform: capitalize;
 }
 
 h2 {
@@ -8,20 +25,19 @@ h2 {
     text-align: center;
 }
 
-table {
-    width: 80%;
-    margin: auto;
+#pagination {
+    margin: 0 auto 0 auto;
+    text-align: center;
 }
 
-table, th, td {
-    border: 1px solid #DDD;
-    border-collapse: collapse;
-}
-
-.table-cell, .table-header {
-    color: #DDD;
-}
-
-.table-header {
-    text-transform: capitalize;
+.btn {
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 1rem;
+    text-align: center;
+    margin-left: 0.5rem;
+    padding: 6px;
+    border: none;
+    min-width: 2rem;
+    max-width: 2rem;
+    border-radius: 4px;
 }

--- a/server.rb
+++ b/server.rb
@@ -14,4 +14,9 @@ get '/hello' do
   'Hello world!'
 end
 
-Rack::Handler::Puma.run(Sinatra::Application, Port: 3000, Host: '0.0.0.0') unless ENV['APP_ENV'] == 'test'
+get '/home' do
+  content_type 'text/html'
+
+  path = File.join(Dir.pwd, 'public', 'index.html')
+  File.open(path)
+end


### PR DESCRIPTION
## Com essa PR, os seguintes objetivos foram concluídos:

- [x] Adicionar novo endereço na página para exibir ao usuário os resultados obtidos através de uma requisição à`GET /tests` feita no código JavaScript usando Fetch API;
![image](https://github.com/eliseuramos93/rebase-labs/assets/111306649/e66f03c1-2c93-4532-a050-df0c2bce68ea)

- [x] Exibir o conteúdo recebido de `GET /tests` de forma paginada, usando apenas JavaScript;
![image](https://github.com/eliseuramos93/rebase-labs/assets/111306649/90bed832-61ef-4709-ae56-055566a906ac)
- [x] Simplificar inicialização do servidor usando Puma;
 
## Débitos
- Encontrei muitas dificuldades para configurar o ambiente de testes para testar o comportamento da página `/home`, pela necessidade de usar um webdriver com navegador para testar a manipulação do DOM através do JavaScript . Tentei a estratégia de executar um navegador (tanto o Chrome quanto o Firefox) dentro do Docker container onde atualmente está rodando a aplicação, mas não tive sucesso.
- Aplicar o conceito de aplicação modular, rodando o backend e frontend em containers separados.

Ambos os débitos serão tratados em uma PR futura.