### PR TITLE
Configura Capybara para testar páginas com JavaScript

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,8 @@ group :development, :test do
 end
 
 group :test do
+  gem 'capybara'
+  gem 'selenium-webdriver'
   gem 'simplecov', require: false
+  gem 'webdriver'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,19 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     base64 (0.2.0)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     csv (3.2.8)
     debug (1.9.1)
       irb (~> 1.10)
@@ -15,9 +26,17 @@ GEM
       reline (>= 0.4.2)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
+    matrix (0.4.2)
+    mini_mime (1.1.5)
+    mini_portile2 (2.8.5)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     nio4r (2.7.0)
+    nokogiri (1.16.2)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.16.2-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -25,6 +44,7 @@ GEM
     pg (1.5.6)
     psych (5.1.2)
       stringio
+    public_suffix (5.0.4)
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
@@ -74,6 +94,12 @@ GEM
       parser (>= 3.3.0.4)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    rubyzip (2.3.2)
+    selenium-webdriver (4.18.1)
+      base64 (~> 0.2)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -89,13 +115,18 @@ GEM
     stringio (3.1.0)
     tilt (2.3.0)
     unicode-display_width (2.5.0)
+    webdriver (0.19.0)
     webrick (1.8.1)
+    websocket (1.2.10)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
   x86_64-linux
 
 DEPENDENCIES
+  capybara
   csv
   debug (>= 1.0.0)
   pg
@@ -105,8 +136,10 @@ DEPENDENCIES
   rackup
   rspec
   rubocop (~> 1.61)
+  selenium-webdriver
   simplecov
   sinatra
+  webdriver
 
 BUNDLED WITH
    2.5.3

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ docker compose down
 ```
 ## Endpoints disponíveis
 
+### GET /
+```bash
+http://localhost:3000/
+```
+- **Status**: 200 (OK)
+- **Corpo da resposta**: Página web que exibe os resultados de `GET /tests` em formato de tabela dentro de uma página reativa, renderizando 100 conteúdos por vez.
+
 ### GET /tests
 ```bash
 http://localhost:3000/tests ou
@@ -48,10 +55,3 @@ GET '/tests'
 ```
 - **Status**: 200 (OK)
 - **Corpo da resposta**: Arquivo JSON com os resultados dos exames cadastrados na plataforma
-
-### GET /home
-```bash
-http://localhost:3000/home
-```
-- **Status**: 200 (OK)
-- **Corpo da resposta**: Página web que exibe os resultados de `GET /tests` em formato de tabela dentro de uma página reativa, renderizando 100 conteúdos por vez.

--- a/public/main.js
+++ b/public/main.js
@@ -1,8 +1,7 @@
-const tests_url = 'http://localhost:3000/tests'
-
 fetch(tests_url)
   .then((response) => response.json())
   .then((data) => {
+    console.log('consegui pegar os dados');
     const table = document.getElementById('tbody')
     const pagination = document.getElementById('pagination');
     const itemsPerPage = 100;

--- a/server.rb
+++ b/server.rb
@@ -10,10 +10,6 @@ get '/tests' do
   DatabaseService.select_all_tests(connection:)
 end
 
-get '/hello' do
-  'Hello world!'
-end
-
-get '/home' do
+get '/' do
   erb :index
 end

--- a/server.rb
+++ b/server.rb
@@ -15,8 +15,5 @@ get '/hello' do
 end
 
 get '/home' do
-  content_type 'text/html'
-
-  path = File.join(Dir.pwd, 'public', 'index.html')
-  File.open(path)
+  erb :index
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,16 +1,5 @@
 ENV['APP_ENV'] = 'test'
 
-require 'simplecov'
-SimpleCov.start do
-  # add_filter Dir.pwd.concat('/import_from_csv.rb')
-end
-
-require_relative '../server'
-require 'rack/test'
-require 'rspec'
-require 'debug'
-require 'pg'
-
 TEST_DB = {
   dbname: 'postgres-test',
   user: 'postgres-test',
@@ -19,8 +8,25 @@ TEST_DB = {
   host: 'postgres-test'
 }.freeze
 
+require_relative '../server'
+require 'capybara/rspec'
+require 'debug'
+require 'pg'
+require 'rack/test'
+require 'rspec'
+require 'simplecov'
+require 'selenium-webdriver'
+require 'webdriver'
+
+SimpleCov.start
+Capybara.app = Sinatra::Application
+Capybara.server = :puma, { Silent: true }
+Capybara.javascript_driver = :selenium_headless
+Capybara.default_driver = :rack_test
+
 RSpec.configure do |config|
   include Rack::Test::Methods
+  Capybara.server_port = 4242
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/system/server_spec.rb
+++ b/spec/system/server_spec.rb
@@ -7,15 +7,6 @@ def app
 end
 
 RSpec.describe Sinatra::Application, type: :system do
-  context 'GET /hello' do
-    it 'fala Hello world! para o usuário' do
-      get '/hello'
-
-      expect(last_response).to be_ok
-      expect(last_response.body).to include 'Hello world!'
-    end
-  end
-
   context 'GET /tests' do
     it 'retorna um arquivo JSON com o resultado dos testes' do
       file_path = File.join(Dir.pwd, 'spec', 'support', 'assets', 'csvs', 'test_data.csv')
@@ -48,14 +39,14 @@ RSpec.describe Sinatra::Application, type: :system do
     end
   end
 
-  context 'GET /home' do
+  context 'GET /' do
     it 'retorna uma tabela com as informações dos exames', js: true do
       file_path = File.join(Dir.pwd, 'spec', 'support', 'assets', 'csvs', 'test_data.csv')
       converter = CSVConverter.new(CSVToJsonStrategy)
       json_data = JSON.parse(converter.convert(file_path))
       DatabaseService.insert_data(json_data:)
 
-      visit '/home'
+      visit '/'
 
       expect(page).to have_content 'Resultados dos Exames'
       expect(page).to have_content '048.973.170-88'

--- a/spec/system/server_spec.rb
+++ b/spec/system/server_spec.rb
@@ -47,4 +47,33 @@ RSpec.describe Sinatra::Application, type: :system do
       expect(json_response.first['resultado tipo exame']).to eq '97'
     end
   end
+
+  context 'GET /home' do
+    it 'retorna uma tabela com as informações dos exames', js: true do
+      file_path = File.join(Dir.pwd, 'spec', 'support', 'assets', 'csvs', 'test_data.csv')
+      converter = CSVConverter.new(CSVToJsonStrategy)
+      json_data = JSON.parse(converter.convert(file_path))
+      DatabaseService.insert_data(json_data:)
+
+      visit '/home'
+
+      expect(page).to have_content 'Resultados dos Exames'
+      expect(page).to have_content '048.973.170-88'
+      expect(page).to have_content 'Emilly Batista Neto'
+      expect(page).to have_content 'gerald.crona@ebert-quigley.com'
+      expect(page).to have_content '2001-03-11'
+      expect(page).to have_content '165 Rua Rafaela'
+      expect(page).to have_content 'Ituverava'
+      expect(page).to have_content 'Alagoas'
+      expect(page).to have_content 'B000BJ20J4'
+      expect(page).to have_content 'PI'
+      expect(page).to have_content 'Maria Luiza Pires'
+      expect(page).to have_content 'denna@wisozk.biz'
+      expect(page).to have_content 'IQCZ17'
+      expect(page).to have_content '2021-08-05'
+      expect(page).to have_content 'hemácias'
+      expect(page).to have_content '45-52'
+      expect(page).to have_content '97'
+    end
+  end
 end

--- a/views/index.erb
+++ b/views/index.erb
@@ -21,6 +21,13 @@
         </div>
         <div id="pagination"></div>
     </section>
+    <script>
+        <% if ENV['APP_ENV'] == 'test' %>
+            const tests_url = 'http://127.0.0.1:4242/tests'
+        <% else %>
+            const tests_url = 'http://localhost:3000/tests'
+        <% end %>
+    </script>
     <script src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Issues resolvidas
- Resolve #6 
- Resolve #7 
- Resolve #8 

# Com essa PR, os seguintes objetivos são concluídos:
- [x] Possibilita testes de sistema capazes de interpretar alterações no DOM efetuadas através de JavaScript;
- [x] Altera a rota '/home` para ser a página inicial da aplicação;
- [x] Aplicação retorna à 100% de cobertura de testes;