### PR TITLE
 Exibir detalhes de um exame em formato HTML a partir do token do resultado

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,162 @@ http://localhost:3000/
 http://localhost:3000/tests ou
 GET '/tests'
 ```
+#### Com sucesso
 - **Status**: 200 (OK)
 - **Corpo da resposta**: Arquivo JSON com os resultados dos exames cadastrados na plataforma
+- **Exemplo de retorno**:
+
+```json
+[
+  {
+    "result_token": "00S0MD",
+    "date": "2022-03-03",
+    "full_name": "Ladislau Duarte",
+    "cpf": "099.204.552-53",
+    "email": "lisha@rosenbaum.org",
+    "birth_date": "1981-02-02",
+    "doctor": {
+      "crm": "B000BJ8TIA",
+      "crm_state": "PR",
+      "full_name": "Ana Sophia Aparício Neto"
+    },
+    "tests": [
+      {
+        "type": "hemácias",
+        "limits": "45-52",
+        "results": "45"
+      },
+      {
+        "type": "leucócitos",
+        "limits": "9-61",
+        "results": "82"
+      },
+      [...],
+      {
+        "type": "ácido úrico",
+        "limits": "15-61",
+        "results": "3"
+      }
+    ]
+  },
+  {
+    "result_token": "06LD0G",
+    "date": "2021-05-15",
+    "full_name": "Valentina Cruz",
+    "cpf": "003.596.348-42",
+    "email": "cortez.dickens@farrell.name",
+    "birth_date": "1979-04-04",
+    "doctor": {
+      "crm": "B00067668W",
+      "crm_state": "RS",
+      "full_name": "Félix Garcês"
+    },
+    "tests": [
+      {
+        "type": "hemácias",
+        "limits": "45-52",
+        "results": "77"
+      },
+      {
+        "type": "leucócitos",
+        "limits": "9-61",
+        "results": "89"
+      },
+      [...],
+      {
+        "type": "ácido úrico",
+        "limits": "15-61",
+        "results": "39"
+      }
+    ]
+  },
+]
+```
+#### Erro na conexão com banco de dados
+- **Status**: 200 (OK)
+- **Corpo da resposta**: Arquivo JSON com mensagem de erro
+- **Exemplo de retorno**:
+```json
+{
+  errors: {
+    message: "Não foi possível conectar-se ao banco de dados."
+  }
+}
+```
+
+### GET /tests/:result_token
+```bash
+http://localhost:3000/tests/:result_token ou
+GET '/tests'
+```
+- **Status**: 200 (OK)
+- **Corpo da resposta**: Arquivo JSON com o exame encontrado através da pesquisa por 
+- **Exemplo de retorno**:
+
+```json
+{
+  "result_token": "00S0MD",
+  "date": "2022-03-03",
+  "full_name": "Ladislau Duarte",
+  "cpf": "099.204.552-53",
+  "email": "lisha@rosenbaum.org",
+  "birth_date": "1981-02-02",
+  "doctor": {
+    "crm": "B000BJ8TIA",
+    "crm_state": "PR",
+    "full_name": "Ana Sophia Aparício Neto"
+  },
+  "tests": [
+    {
+      "type": "hemácias",
+      "limits": "45-52",
+      "results": "45"
+    },
+    {
+      "type": "leucócitos",
+      "limits": "9-61",
+      "results": "82"
+    },
+    [...],
+    {
+      "type": "ácido úrico",
+      "limits": "15-61",
+      "results": "3"
+    }
+  ]
+}
+```
+#### Erro na conexão com banco de dados
+- **Status**: 200 (OK)
+- **Corpo da resposta**: Arquivo JSON com mensagem de erro
+- **Exemplo de retorno**:
+```json
+{
+  errors: {
+    message: "Não foi possível conectar-se ao banco de dados."
+  }
+}
+```
+#### Exame não foi encontrado no banco de dados
+- **Status**: 200 (OK)
+- **Corpo da resposta**: Arquivo JSON com mensagem de erro
+- **Exemplo de retorno**:
+```json
+{
+  errors: {
+    message: "Não foi encontrado nenhum exame com o token informado."
+  }
+}
+```
+
+#### Erro na conexão com banco de dados
+- **Status**: 200 (OK)
+- **Corpo da resposta**: Arquivo JSON com mensagem de erro
+- **Exemplo de retorno**:
+```json
+{
+  errors: {
+    message: "Não foi possível conectar-se ao banco de dados."
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ GET '/tests'
 - **Exemplo de retorno**:
 ```json
 {
-  errors: {
-    message: "Não foi possível conectar-se ao banco de dados."
+  "errors": {
+    "message": "Não foi possível conectar-se ao banco de dados."
   }
 }
 ```
@@ -184,8 +184,8 @@ GET '/tests'
 - **Exemplo de retorno**:
 ```json
 {
-  errors: {
-    message: "Não foi possível conectar-se ao banco de dados."
+  "errors": {
+    "message": "Não foi possível conectar-se ao banco de dados."
   }
 }
 ```
@@ -195,8 +195,8 @@ GET '/tests'
 - **Exemplo de retorno**:
 ```json
 {
-  errors: {
-    message: "Não foi encontrado nenhum exame com o token informado."
+  "errors": {
+    "message": "Não foi encontrado nenhum exame com o token informado."
   }
 }
 ```
@@ -207,8 +207,8 @@ GET '/tests'
 - **Exemplo de retorno**:
 ```json
 {
-  errors: {
-    message: "Não foi possível conectar-se ao banco de dados."
+  "errors": {
+    "message": "Não foi possível conectar-se ao banco de dados."
   }
 }
 ```

--- a/lib/models/examination_model.rb
+++ b/lib/models/examination_model.rb
@@ -40,7 +40,7 @@ class Examination < ApplicationModel
 
   private_class_method def self.create_examination_hash(examination:, connection:)
     exam_id = examination['id'].to_i
-    tests_array = connection.exec("SELECT type, limits, results FROM tests WHERE examination_id = #{exam_id}").to_a
+    tests_array = select_distinct_tests_from_exam_id(connection:, exam_id:)
 
     { result_token: examination['result_token'],
       date: examination['date'],
@@ -58,5 +58,9 @@ class Examination < ApplicationModel
 
   private_class_method def self.examination_not_found
     { errors: { message: 'Não foi encontrado nenhum exame com o token informado.' } }
+  end
+
+  private_class_method def self.select_distinct_tests_from_exam_id(connection:, exam_id:)
+    connection.exec("SELECT DISTINCT ON (type) type, limits, results FROM tests WHERE examination_id = #{exam_id}").to_a
   end
 end

--- a/lib/models/examination_model.rb
+++ b/lib/models/examination_model.rb
@@ -1,12 +1,6 @@
 require_relative 'application_model'
 
 class Examination < ApplicationModel
-  ALL_EXAMS_SQL = 'SELECT e.id, e.result_token, e.date, p.cpf, p.full_name, p.email, p.birth_date, d.crm, d.crm_state,
-  d.full_name as doctor_name
-  FROM examinations e
-  JOIN patients p ON e.patient_id = p.id
-  JOIN doctors d ON e.doctor_id = d.id'.freeze
-
   attr_accessor :id, :patient_id, :doctor_id, :result_token, :date
 
   def initialize(**attributes)
@@ -18,31 +12,51 @@ class Examination < ApplicationModel
     @date = attributes[:date]
   end
 
-  def self.all_to_json(connection: nil, end_connection: true)
+  def self.select_all_to_json(connection: nil, end_connection: true)
     connection ||= DatabaseService.connect
 
     examinations = connection.exec(ALL_EXAMS_SQL).to_a
     results = examinations.each_with_object([]) do |examination, array|
-      exam_id = examination['id'].to_i
-      tests_array = connection.exec("SELECT type, limits, results FROM tests WHERE examination_id = #{exam_id}").to_a
-      array << format_examination_json(examination:, tests_array:)
+      array << create_examination_hash(examination:, connection:)
     end
     connection.close if end_connection
     results
+  rescue PG::ConnectionBad
+    connection_bad_warning
   end
 
-  private_class_method def self.format_examination_json(examination:, tests_array:)
-    {
-      result_token: examination['result_token'],
+  def self.select_to_json(connection: nil, end_connection: true, result_token:)
+    connection ||= DatabaseService.connect
+
+    examination = connection.exec("#{FIND_EXAM_BY_TOKEN} '#{result_token}'").first
+    return examination_not_found unless examination
+
+    result = create_examination_hash(examination:, connection:)
+    connection.close if end_connection
+    result
+  rescue PG::ConnectionBad
+    connection_bad_warning
+  end
+
+  private_class_method def self.create_examination_hash(examination:, connection:)
+    exam_id = examination['id'].to_i
+    tests_array = connection.exec("SELECT type, limits, results FROM tests WHERE examination_id = #{exam_id}").to_a
+
+    { result_token: examination['result_token'],
       date: examination['date'],
       full_name: examination['full_name'],
       cpf: examination['cpf'],
       email: examination['email'],
       birth_date: examination['birth_date'],
       doctor: { crm: examination['crm'], crm_state: examination['crm_state'], full_name: examination['doctor_name'] },
-      tests: tests_array.map { |test| test.transform_keys(&:to_sym) }
-    }
+      tests: tests_array.map { |test| test.transform_keys(&:to_sym) } }
   end
 
-  private_class_method def self.generate_exams_sql; end
+  private_class_method def self.connection_bad_warning
+    { errors: { message: 'Não foi possível conectar-se ao banco de dados.' } }
+  end
+
+  private_class_method def self.examination_not_found
+    { errors: { message: 'Não foi encontrado nenhum exame com o token informado.' } }
+  end
 end

--- a/lib/services/database_service.rb
+++ b/lib/services/database_service.rb
@@ -14,6 +14,20 @@ TEST_DB_CONFIG = {
   host: 'postgres-test'
 }.freeze
 
+ALL_EXAMS_SQL = 'SELECT e.id, e.result_token, e.date, p.cpf, p.full_name, p.email, p.birth_date, d.crm, d.crm_state,
+d.full_name as doctor_name
+FROM examinations e
+JOIN patients p ON e.patient_id = p.id
+JOIN doctors d ON e.doctor_id = d.id
+ORDER BY e.result_token ASC'.freeze
+
+FIND_EXAM_BY_TOKEN = 'SELECT e.id, e.result_token, e.date, p.cpf, p.full_name, p.email, p.birth_date, d.crm,
+d.crm_state, d.full_name as doctor_name
+FROM examinations e
+JOIN patients p ON e.patient_id = p.id
+JOIN doctors d ON e.doctor_id = d.id
+WHERE e.result_token ='.freeze
+
 require 'pg'
 require 'json'
 

--- a/public/style.css
+++ b/public/style.css
@@ -95,3 +95,47 @@ input {
 .search-result-cell {
     text-transform: capitalize;
 }
+
+form {
+    margin: 0 auto 1rem auto;
+    text-align: center;
+}
+
+#alerts {
+    margin: 0 auto 1rem auto;
+    text-align: center;
+}
+
+.alert {
+    padding: 1rem;
+    margin: 0 auto 1rem auto;
+    text-align: center;
+    max-width: 80%;
+    border-radius: 15px;
+}
+
+.warning {
+    background-color: #FFA50070;
+}
+
+.success {
+    background-color: #00800070;
+}
+
+.error {
+    background-color: #FF000080;
+}
+
+dt {
+    font-weight: bold;
+}
+
+#search-exam-results-section {
+    margin: 0 auto 1rem auto;
+    text-align: center;
+    max-width: 80%
+}
+
+#search-exam-info {
+    text-align: left;
+}

--- a/public/style.css
+++ b/public/style.css
@@ -1,5 +1,6 @@
 body {
     background-color: #111;
+    color: #DDD;
     font-family: Helvetica, sans-serif;
 }
 
@@ -13,6 +14,11 @@ table {
     border: 1px solid #DDD;
     width: 90vw; 
     white-space: nowrap;
+}
+
+.search-exam-results {
+    max-width: 90vw;
+    margin: auto;
 }
 
 .table-div {
@@ -68,6 +74,10 @@ h2 {
     border-radius: 4px;
 }
 
+.normal-btn {
+    max-width: none;
+}
+
 .search-field {
     margin-bottom: 1rem;
     text-align: center;
@@ -76,4 +86,12 @@ h2 {
 input {
     width: 20%;
     text-align: center;
+}
+
+.hidden {
+    display: none;
+}
+
+.search-result-cell {
+    text-transform: capitalize;
 }

--- a/server.rb
+++ b/server.rb
@@ -2,12 +2,19 @@ require 'sinatra'
 require 'rack/handler/puma'
 require_relative 'lib/models/examination_model'
 
+get '/' do
+  erb :index
+end
+
 get '/tests' do
   content_type :json
 
-  Examination.all_to_json.to_json
+  Examination.select_all_to_json.to_json
 end
 
-get '/' do
-  erb :index
+get '/tests/:result_token?' do
+  content_type :json
+  return Examination.select_all_to_json.to_json unless params[:result_token]
+
+  Examination.select_to_json(result_token: params[:result_token]).to_json
 end

--- a/spec/models/examination_spec.rb
+++ b/spec/models/examination_spec.rb
@@ -228,12 +228,12 @@ RSpec.describe Examination do
       expect(results[0][:doctor][:crm]).to eq 'B000BJ20J4'
       expect(results[0][:doctor][:crm_state]).to eq 'PI'
       expect(results[0][:doctor][:full_name]).to eq 'Dr. Ross Geller'
-      expect(results[0][:tests][0][:type]).to eq 'Hemácias'
-      expect(results[0][:tests][0][:limits]).to eq '45-52'
-      expect(results[0][:tests][0][:results]).to eq '97'
-      expect(results[0][:tests][1][:type]).to eq 'Glóbulos Neutrônicos'
-      expect(results[0][:tests][1][:limits]).to eq '2-8'
-      expect(results[0][:tests][1][:results]).to eq '5'
+      expect(results[0][:tests][0][:type]).to eq 'Glóbulos Neutrônicos'
+      expect(results[0][:tests][0][:limits]).to eq '2-8'
+      expect(results[0][:tests][0][:results]).to eq '5'
+      expect(results[0][:tests][1][:type]).to eq 'Hemácias'
+      expect(results[0][:tests][1][:limits]).to eq '45-52'
+      expect(results[0][:tests][1][:results]).to eq '97'
     end
 
     it 'retorna um array vazio se não houver exames cadastrados' do
@@ -277,12 +277,12 @@ RSpec.describe Examination do
       expect(result[:doctor][:crm]).to eq 'B000BJ20J4'
       expect(result[:doctor][:crm_state]).to eq 'PI'
       expect(result[:doctor][:full_name]).to eq 'Dr. Ross Geller'
-      expect(result[:tests][0][:type]).to eq 'Hemácias'
-      expect(result[:tests][0][:limits]).to eq '45-52'
-      expect(result[:tests][0][:results]).to eq '97'
-      expect(result[:tests][1][:type]).to eq 'Glóbulos Neutrônicos'
-      expect(result[:tests][1][:limits]).to eq '2-8'
-      expect(result[:tests][1][:results]).to eq '5'
+      expect(result[:tests][0][:type]).to eq 'Glóbulos Neutrônicos'
+      expect(result[:tests][0][:limits]).to eq '2-8'
+      expect(result[:tests][0][:results]).to eq '5'
+      expect(result[:tests][1][:type]).to eq 'Hemácias'
+      expect(result[:tests][1][:limits]).to eq '45-52'
+      expect(result[:tests][1][:results]).to eq '97'
     end
 
     it 'retorna uma mensagem de erro caso não o exame não seja encontrado' do

--- a/spec/system/server_spec.rb
+++ b/spec/system/server_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Sinatra::Application, type: :system do
       Test.create(examination_id: examination.id, type: 'Glóbulos Neutrônicos', limits: '2-8', results: '5')
 
       visit '/'
-      fill_in 'Código do Exame', with: 'SCCP10'
+      fill_in 'Token do exame', with: 'SCCP10'
       click_button 'Buscar'
 
       expect(page).to have_current_path '/'
@@ -79,7 +79,7 @@ RSpec.describe Sinatra::Application, type: :system do
       Test.create(examination_id: examination.id, type: 'Glóbulos Neutrônicos', limits: '2-8', results: '5')
 
       visit '/'
-      fill_in 'Código do Exame', with: ''
+      fill_in 'Token do exame', with: ''
       click_button 'Buscar'
 
       expect(page).to have_current_path '/'
@@ -115,7 +115,7 @@ RSpec.describe Sinatra::Application, type: :system do
       Test.create(examination_id: examination.id, type: 'Glóbulos Neutrônicos', limits: '2-8', results: '5')
 
       visit '/'
-      fill_in 'Código do Exame', with: 'SCCP1910'
+      fill_in 'Token do exame', with: 'SCCP1910'
       click_button 'Buscar'
 
       expect(page).to have_current_path '/'
@@ -128,7 +128,7 @@ RSpec.describe Sinatra::Application, type: :system do
       allow(DatabaseService).to receive(:connect).and_raise(PG::ConnectionBad)
 
       visit '/'
-      fill_in 'Código do Exame', with: 'SCCP1910'
+      fill_in 'Token do exame', with: 'SCCP1910'
       click_button 'Buscar'
 
       expect(page).to have_current_path '/'
@@ -148,7 +148,7 @@ RSpec.describe Sinatra::Application, type: :system do
       Test.create(examination_id: examination.id, type: 'Glóbulos Neutrônicos', limits: '2-8', results: '5')
 
       visit '/'
-      fill_in 'Código do Exame', with: 'SCCP10'
+      fill_in 'Token do exame', with: 'SCCP10'
       click_on 'Buscar'
       click_on 'Voltar para a lista'
 

--- a/spec/system/server_spec.rb
+++ b/spec/system/server_spec.rb
@@ -31,6 +31,147 @@ RSpec.describe Sinatra::Application, type: :system do
       expect(page).to have_content 'PI'
       expect(page).to have_content 'Dr. Ross Geller'
     end
+
+    it 'carrega as informações do exame pesquisado através do formulário com sucesso', js: true do
+      patient = Patient.create(cpf: '283.368.670-66', full_name: 'Reginaldo Rossi', email: 'reidobrega@gmail.com',
+                               birth_date: '1944-02-14', address: '200 Rua do Garçom', city: 'Recife', state: 'PE')
+      doctor = Doctor.create(crm: 'B000BJ20J4', crm_state: 'PI', full_name: 'Dr. Ross Geller',
+                             email: 'wewereonabreak@gmail.com')
+      examination = Examination.create(patient_id: patient.id, doctor_id: doctor.id, result_token: 'SCCP10',
+                                       date: '2023-10-31')
+      Test.create(examination_id: examination.id, type: 'Hemácias', limits: '45-52', results: '97')
+      Test.create(examination_id: examination.id, type: 'Glóbulos Neutrônicos', limits: '2-8', results: '5')
+
+      visit '/'
+      fill_in 'Código do Exame', with: 'SCCP10'
+      click_button 'Buscar'
+
+      expect(page).to have_current_path '/'
+
+      expect(page).to have_content 'Exame encontrado com sucesso!'
+      expect(page).to have_content "Exame:\nSCCP10"
+      expect(page).to have_content "Data do resultado (AAAA-MM-DD):\n2023-10-31"
+      expect(page).to have_content "CPF:\n283.368.670-66"
+      expect(page).to have_content "Nome:\nReginaldo Rossi"
+      expect(page).to have_content "E-mail:\nreidobrega@gmail.com"
+      expect(page).to have_content "Data de nascimento (AAAA-MM-DD):\n1944-02-14"
+      expect(page).to have_content "Médico(a):\nDr. Ross Geller"
+      expect(page).to have_content "CRM:\nB000BJ20J4"
+      expect(page).to have_content "Estado do CRM:\nPI"
+      expect(page).to have_content 'Hemácias'
+      expect(page).to have_content 'Limites'
+      expect(page).to have_content '45-52'
+      expect(page).to have_content 'Resultado'
+      expect(page).to have_content '97'
+      expect(page).to have_content 'Glóbulos Neutrônicos'
+      expect(page).to have_content '2-8'
+      expect(page).to have_content '5'
+    end
+
+    it 'não executa a busca caso o campo de pesquisa esteja vazio', js: true do
+      patient = Patient.create(cpf: '283.368.670-66', full_name: 'Reginaldo Rossi', email: 'reidobrega@gmail.com',
+                               birth_date: '1944-02-14', address: '200 Rua do Garçom', city: 'Recife', state: 'PE')
+      doctor = Doctor.create(crm: 'B000BJ20J4', crm_state: 'PI', full_name: 'Dr. Ross Geller',
+                             email: 'wewereonabreak@gmail.com')
+      examination = Examination.create(patient_id: patient.id, doctor_id: doctor.id, result_token: 'SCCP10',
+                                       date: '2023-10-31')
+      Test.create(examination_id: examination.id, type: 'Hemácias', limits: '45-52', results: '97')
+      Test.create(examination_id: examination.id, type: 'Glóbulos Neutrônicos', limits: '2-8', results: '5')
+
+      visit '/'
+      fill_in 'Código do Exame', with: ''
+      click_button 'Buscar'
+
+      expect(page).to have_current_path '/'
+      expect(page).to have_content 'É necessário informar o código do exame para realizar a busca.'
+      expect(page).not_to have_button 'Voltar para a lista'
+      expect(page).not_to have_content 'Exame encontrado com sucesso!'
+      expect(page).to have_content 'SCCP10'
+      expect(page).to have_content '2023-10-31'
+      expect(page).to have_content '283.368.670-66'
+      expect(page).to have_content 'Reginaldo Rossi'
+      expect(page).to have_content 'reidobrega@gmail.com'
+      expect(page).to have_content '1944-02-14'
+      expect(page).to have_content 'Dr. Ross Geller'
+      expect(page).to have_content 'B000BJ20J4'
+      expect(page).to have_content 'PI'
+      expect(page).not_to have_content 'Hemácias'
+      expect(page).not_to have_content 'Glóbulos Neutrônicos'
+      expect(page).not_to have_content 'Limites'
+      expect(page).not_to have_content '45-52'
+      expect(page).not_to have_content '2-8'
+      expect(page).not_to have_content '97'
+      expect(page).not_to have_content '5'
+    end
+
+    it 'informa uma mensagem de erro caso o exame pesquisado não seja encontrado', js: true do
+      patient = Patient.create(cpf: '283.368.670-66', full_name: 'Reginaldo Rossi', email: 'reidobrega@gmail.com',
+                               birth_date: '1944-02-14', address: '200 Rua do Garçom', city: 'Recife', state: 'PE')
+      doctor = Doctor.create(crm: 'B000BJ20J4', crm_state: 'PI', full_name: 'Dr. Ross Geller',
+                             email: 'wewereonabreak@gmail.com')
+      examination = Examination.create(patient_id: patient.id, doctor_id: doctor.id, result_token: 'SCCP10',
+                                       date: '2023-10-31')
+      Test.create(examination_id: examination.id, type: 'Hemácias', limits: '45-52', results: '97')
+      Test.create(examination_id: examination.id, type: 'Glóbulos Neutrônicos', limits: '2-8', results: '5')
+
+      visit '/'
+      fill_in 'Código do Exame', with: 'SCCP1910'
+      click_button 'Buscar'
+
+      expect(page).to have_current_path '/'
+      expect(page).to have_content 'Não foi encontrado nenhum exame com o token informado.'
+      expect(page).not_to have_content 'Hemácias'
+      expect(page).not_to have_content 'Glóbulos Neutrônicos'
+    end
+
+    it 'informa uma mensagem de erro caso o banco de dados não esteja disponível', js: true do
+      allow(DatabaseService).to receive(:connect).and_raise(PG::ConnectionBad)
+
+      visit '/'
+      fill_in 'Código do Exame', with: 'SCCP1910'
+      click_button 'Buscar'
+
+      expect(page).to have_current_path '/'
+      expect(page).to have_content 'Não foi possível conectar-se ao banco de dados.'
+      expect(page).not_to have_content 'Hemácias'
+      expect(page).not_to have_content 'Glóbulos Neutrônicos'
+    end
+
+    it 'retorna para a lista de exames caso o botão "Voltar para a lista" seja clicado', js: true do
+      patient = Patient.create(cpf: '283.368.670-66', full_name: 'Reginaldo Rossi', email: 'reidobrega@gmail.com',
+                               birth_date: '1944-02-14', address: '200 Rua do Garçom', city: 'Recife', state: 'PE')
+      doctor = Doctor.create(crm: 'B000BJ20J4', crm_state: 'PI', full_name: 'Dr. Ross Geller',
+                             email: 'wewereonabreak@gmail.com')
+      examination = Examination.create(patient_id: patient.id, doctor_id: doctor.id, result_token: 'SCCP10',
+                                       date: '2023-10-31')
+      Test.create(examination_id: examination.id, type: 'Hemácias', limits: '45-52', results: '97')
+      Test.create(examination_id: examination.id, type: 'Glóbulos Neutrônicos', limits: '2-8', results: '5')
+
+      visit '/'
+      fill_in 'Código do Exame', with: 'SCCP10'
+      click_on 'Buscar'
+      click_on 'Voltar para a lista'
+
+      expect(page).to have_current_path '/'
+      expect(page).not_to have_button 'Voltar para a lista'
+      expect(page).not_to have_content 'Exame encontrado com sucesso!'
+      expect(page).to have_content 'SCCP10'
+      expect(page).to have_content '2023-10-31'
+      expect(page).to have_content '283.368.670-66'
+      expect(page).to have_content 'Reginaldo Rossi'
+      expect(page).to have_content 'reidobrega@gmail.com'
+      expect(page).to have_content '1944-02-14'
+      expect(page).to have_content 'Dr. Ross Geller'
+      expect(page).to have_content 'B000BJ20J4'
+      expect(page).to have_content 'PI'
+      expect(page).not_to have_content 'Hemácias'
+      expect(page).not_to have_content 'Glóbulos Neutrônicos'
+      expect(page).not_to have_content 'Limites'
+      expect(page).not_to have_content '45-52'
+      expect(page).not_to have_content '2-8'
+      expect(page).not_to have_content '97'
+      expect(page).not_to have_content '5'
+    end
   end
 
   context 'GET /tests' do
@@ -60,12 +201,12 @@ RSpec.describe Sinatra::Application, type: :system do
       expect(json_response[0]['doctor']['crm']).to eq 'B000BJ20J4'
       expect(json_response[0]['doctor']['crm_state']).to eq 'PI'
       expect(json_response[0]['doctor']['full_name']).to eq 'Dr. Ross Geller'
-      expect(json_response[0]['tests'][0]['type']).to eq 'Hemácias'
-      expect(json_response[0]['tests'][0]['limits']).to eq '45-52'
-      expect(json_response[0]['tests'][0]['results']).to eq '97'
-      expect(json_response[0]['tests'][1]['type']).to eq 'Glóbulos Neutrônicos'
-      expect(json_response[0]['tests'][1]['limits']).to eq '2-8'
-      expect(json_response[0]['tests'][1]['results']).to eq '5'
+      expect(json_response[0]['tests'][0]['type']).to eq 'Glóbulos Neutrônicos'
+      expect(json_response[0]['tests'][0]['limits']).to eq '2-8'
+      expect(json_response[0]['tests'][0]['results']).to eq '5'
+      expect(json_response[0]['tests'][1]['type']).to eq 'Hemácias'
+      expect(json_response[0]['tests'][1]['limits']).to eq '45-52'
+      expect(json_response[0]['tests'][1]['results']).to eq '97'
     end
 
     it 'retorna um array vazio se não houver exames cadastrados' do
@@ -114,12 +255,12 @@ RSpec.describe Sinatra::Application, type: :system do
       expect(json_response['doctor']['crm']).to eq 'B000BJ20J4'
       expect(json_response['doctor']['crm_state']).to eq 'PI'
       expect(json_response['doctor']['full_name']).to eq 'Dr. Ross Geller'
-      expect(json_response['tests'][0]['type']).to eq 'Hemácias'
-      expect(json_response['tests'][0]['limits']).to eq '45-52'
-      expect(json_response['tests'][0]['results']).to eq '97'
-      expect(json_response['tests'][1]['type']).to eq 'Glóbulos Neutrônicos'
-      expect(json_response['tests'][1]['limits']).to eq '2-8'
-      expect(json_response['tests'][1]['results']).to eq '5'
+      expect(json_response['tests'][0]['type']).to eq 'Glóbulos Neutrônicos'
+      expect(json_response['tests'][0]['limits']).to eq '2-8'
+      expect(json_response['tests'][0]['results']).to eq '5'
+      expect(json_response['tests'][1]['type']).to eq 'Hemácias'
+      expect(json_response['tests'][1]['limits']).to eq '45-52'
+      expect(json_response['tests'][1]['results']).to eq '97'
     end
 
     it 'retorna todos os testes caso result_token não seja informado' do
@@ -150,12 +291,12 @@ RSpec.describe Sinatra::Application, type: :system do
       expect(json_response[0]['doctor']['crm']).to eq 'B000BJ20J4'
       expect(json_response[0]['doctor']['crm_state']).to eq 'PI'
       expect(json_response[0]['doctor']['full_name']).to eq 'Dr. Ross Geller'
-      expect(json_response[0]['tests'][0]['type']).to eq 'Hemácias'
-      expect(json_response[0]['tests'][0]['limits']).to eq '45-52'
-      expect(json_response[0]['tests'][0]['results']).to eq '97'
-      expect(json_response[0]['tests'][1]['type']).to eq 'Glóbulos Neutrônicos'
-      expect(json_response[0]['tests'][1]['limits']).to eq '2-8'
-      expect(json_response[0]['tests'][1]['results']).to eq '5'
+      expect(json_response[0]['tests'][0]['type']).to eq 'Glóbulos Neutrônicos'
+      expect(json_response[0]['tests'][0]['limits']).to eq '2-8'
+      expect(json_response[0]['tests'][0]['results']).to eq '5'
+      expect(json_response[0]['tests'][1]['type']).to eq 'Hemácias'
+      expect(json_response[0]['tests'][1]['limits']).to eq '45-52'
+      expect(json_response[0]['tests'][1]['results']).to eq '97'
     end
 
     it 'retorna uma mensagem de erro caso o token não exista' do

--- a/spec/system/server_spec.rb
+++ b/spec/system/server_spec.rb
@@ -10,41 +10,6 @@ def app
 end
 
 RSpec.describe Sinatra::Application, type: :system do
-  context 'GET /tests' do
-    it 'retorna um arquivo JSON com o resultado dos testes' do
-      patient = Patient.create(cpf: '283.368.670-66', full_name: 'Reginaldo Rossi', email: 'reidobrega@gmail.com',
-                               birth_date: '1944-02-14', address: '200 Rua do Garçom', city: 'Recife', state: 'PE')
-      doctor = Doctor.create(crm: 'B000BJ20J4', crm_state: 'PI', full_name: 'Dr. Ross Geller',
-                             email: 'wewereonabreak@gmail.com')
-      examination = Examination.create(patient_id: patient.id, doctor_id: doctor.id, result_token: 'SCCP10',
-                                       date: '2023-10-31')
-      Test.create(examination_id: examination.id, type: 'Hemácias', limits: '45-52', results: '97')
-      Test.create(examination_id: examination.id, type: 'Glóbulos Neutrônicos', limits: '2-8', results: '5')
-
-      get '/tests'
-
-      expect(last_response).to be_ok
-      expect(last_response.content_type).to include 'application/json'
-      json_response = JSON.parse(last_response.body)
-      expect(json_response.count).to eq 1
-      expect(json_response[0]['result_token']).to eq 'SCCP10'
-      expect(json_response[0]['date']).to eq '2023-10-31'
-      expect(json_response[0]['cpf']).to eq '283.368.670-66'
-      expect(json_response[0]['full_name']).to eq 'Reginaldo Rossi'
-      expect(json_response[0]['email']).to eq 'reidobrega@gmail.com'
-      expect(json_response[0]['birth_date']).to eq '1944-02-14'
-      expect(json_response[0]['doctor']['crm']).to eq 'B000BJ20J4'
-      expect(json_response[0]['doctor']['crm_state']).to eq 'PI'
-      expect(json_response[0]['doctor']['full_name']).to eq 'Dr. Ross Geller'
-      expect(json_response[0]['tests'][0]['type']).to eq 'Hemácias'
-      expect(json_response[0]['tests'][0]['limits']).to eq '45-52'
-      expect(json_response[0]['tests'][0]['results']).to eq '97'
-      expect(json_response[0]['tests'][1]['type']).to eq 'Glóbulos Neutrônicos'
-      expect(json_response[0]['tests'][1]['limits']).to eq '2-8'
-      expect(json_response[0]['tests'][1]['results']).to eq '5'
-    end
-  end
-
   context 'GET /' do
     it 'retorna uma tabela com as informações dos exames', js: true do
       patient = Patient.create(cpf: '283.368.670-66', full_name: 'Reginaldo Rossi', email: 'reidobrega@gmail.com',
@@ -65,6 +30,163 @@ RSpec.describe Sinatra::Application, type: :system do
       expect(page).to have_content 'B000BJ20J4'
       expect(page).to have_content 'PI'
       expect(page).to have_content 'Dr. Ross Geller'
+    end
+  end
+
+  context 'GET /tests' do
+    it 'retorna um arquivo JSON com o resultado dos testes' do
+      patient = Patient.create(cpf: '283.368.670-66', full_name: 'Reginaldo Rossi', email: 'reidobrega@gmail.com',
+                               birth_date: '1944-02-14', address: '200 Rua do Garçom', city: 'Recife', state: 'PE')
+      doctor = Doctor.create(crm: 'B000BJ20J4', crm_state: 'PI', full_name: 'Dr. Ross Geller',
+                             email: 'wewereonabreak@gmail.com')
+      examination = Examination.create(patient_id: patient.id, doctor_id: doctor.id, result_token: 'SCCP10',
+                                       date: '2023-10-31')
+      Test.create(examination_id: examination.id, type: 'Hemácias', limits: '45-52', results: '97')
+      Test.create(examination_id: examination.id, type: 'Glóbulos Neutrônicos', limits: '2-8', results: '5')
+
+      get '/tests'
+
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to include 'application/json'
+      json_response = JSON.parse(last_response.body)
+      expect(json_response.class).to be Array
+      expect(json_response.count).to eq 1
+      expect(json_response[0]['result_token']).to eq 'SCCP10'
+      expect(json_response[0]['date']).to eq '2023-10-31'
+      expect(json_response[0]['cpf']).to eq '283.368.670-66'
+      expect(json_response[0]['full_name']).to eq 'Reginaldo Rossi'
+      expect(json_response[0]['email']).to eq 'reidobrega@gmail.com'
+      expect(json_response[0]['birth_date']).to eq '1944-02-14'
+      expect(json_response[0]['doctor']['crm']).to eq 'B000BJ20J4'
+      expect(json_response[0]['doctor']['crm_state']).to eq 'PI'
+      expect(json_response[0]['doctor']['full_name']).to eq 'Dr. Ross Geller'
+      expect(json_response[0]['tests'][0]['type']).to eq 'Hemácias'
+      expect(json_response[0]['tests'][0]['limits']).to eq '45-52'
+      expect(json_response[0]['tests'][0]['results']).to eq '97'
+      expect(json_response[0]['tests'][1]['type']).to eq 'Glóbulos Neutrônicos'
+      expect(json_response[0]['tests'][1]['limits']).to eq '2-8'
+      expect(json_response[0]['tests'][1]['results']).to eq '5'
+    end
+
+    it 'retorna um array vazio se não houver exames cadastrados' do
+      get '/tests'
+
+      expect(last_response).to be_ok
+      json_response = JSON.parse(last_response.body)
+      expect(json_response).to eq []
+    end
+
+    it 'retorna uma mensagem de erro caso a conexão com o banco de dados falhe' do
+      allow(DatabaseService).to receive(:connect).and_raise(PG::ConnectionBad)
+
+      get '/tests'
+
+      expect(last_response).to be_ok
+      json_response = JSON.parse(last_response.body)
+      expect(json_response.class).to eq Hash
+      expect(json_response['errors']['message']).to eq 'Não foi possível conectar-se ao banco de dados.'
+    end
+  end
+
+  context 'GET /tests/:result_token' do
+    it 'retorna o teste pesquisado com sucesso' do
+      patient = Patient.create(cpf: '283.368.670-66', full_name: 'Reginaldo Rossi', email: 'reidobrega@gmail.com',
+                               birth_date: '1944-02-14', address: '200 Rua do Garçom', city: 'Recife', state: 'PE')
+      doctor = Doctor.create(crm: 'B000BJ20J4', crm_state: 'PI', full_name: 'Dr. Ross Geller',
+                             email: 'wewereonabreak@gmail.com')
+      examination = Examination.create(patient_id: patient.id, doctor_id: doctor.id, result_token: 'SCCP10',
+                                       date: '2023-10-31')
+      Test.create(examination_id: examination.id, type: 'Hemácias', limits: '45-52', results: '97')
+      Test.create(examination_id: examination.id, type: 'Glóbulos Neutrônicos', limits: '2-8', results: '5')
+
+      get '/tests/SCCP10'
+
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to include 'application/json'
+      json_response = JSON.parse(last_response.body)
+      expect(json_response.class).to be Hash
+      expect(json_response['result_token']).to eq 'SCCP10'
+      expect(json_response['date']).to eq '2023-10-31'
+      expect(json_response['cpf']).to eq '283.368.670-66'
+      expect(json_response['full_name']).to eq 'Reginaldo Rossi'
+      expect(json_response['email']).to eq 'reidobrega@gmail.com'
+      expect(json_response['birth_date']).to eq '1944-02-14'
+      expect(json_response['doctor']['crm']).to eq 'B000BJ20J4'
+      expect(json_response['doctor']['crm_state']).to eq 'PI'
+      expect(json_response['doctor']['full_name']).to eq 'Dr. Ross Geller'
+      expect(json_response['tests'][0]['type']).to eq 'Hemácias'
+      expect(json_response['tests'][0]['limits']).to eq '45-52'
+      expect(json_response['tests'][0]['results']).to eq '97'
+      expect(json_response['tests'][1]['type']).to eq 'Glóbulos Neutrônicos'
+      expect(json_response['tests'][1]['limits']).to eq '2-8'
+      expect(json_response['tests'][1]['results']).to eq '5'
+    end
+
+    it 'retorna todos os testes caso result_token não seja informado' do
+      patient = Patient.create(cpf: '283.368.670-66', full_name: 'Reginaldo Rossi', email: 'reidobrega@gmail.com',
+                               birth_date: '1944-02-14', address: '200 Rua do Garçom', city: 'Recife', state: 'PE')
+      doctor = Doctor.create(crm: 'B000BJ20J4', crm_state: 'PI', full_name: 'Dr. Ross Geller',
+                             email: 'wewereonabreak@gmail.com')
+      examination = Examination.create(patient_id: patient.id, doctor_id: doctor.id, result_token: 'SCCP10',
+                                       date: '2023-10-31')
+      Examination.create(patient_id: patient.id, doctor_id: doctor.id, result_token: 'SCCP11',
+                         date: '2023-09-01')
+      Test.create(examination_id: examination.id, type: 'Hemácias', limits: '45-52', results: '97')
+      Test.create(examination_id: examination.id, type: 'Glóbulos Neutrônicos', limits: '2-8', results: '5')
+
+      get '/tests/'
+
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to include 'application/json'
+      json_response = JSON.parse(last_response.body)
+      expect(json_response.class).to be Array
+      expect(json_response.count).to eq 2
+      expect(json_response[0]['result_token']).to eq 'SCCP10'
+      expect(json_response[0]['date']).to eq '2023-10-31'
+      expect(json_response[0]['cpf']).to eq '283.368.670-66'
+      expect(json_response[0]['full_name']).to eq 'Reginaldo Rossi'
+      expect(json_response[0]['email']).to eq 'reidobrega@gmail.com'
+      expect(json_response[0]['birth_date']).to eq '1944-02-14'
+      expect(json_response[0]['doctor']['crm']).to eq 'B000BJ20J4'
+      expect(json_response[0]['doctor']['crm_state']).to eq 'PI'
+      expect(json_response[0]['doctor']['full_name']).to eq 'Dr. Ross Geller'
+      expect(json_response[0]['tests'][0]['type']).to eq 'Hemácias'
+      expect(json_response[0]['tests'][0]['limits']).to eq '45-52'
+      expect(json_response[0]['tests'][0]['results']).to eq '97'
+      expect(json_response[0]['tests'][1]['type']).to eq 'Glóbulos Neutrônicos'
+      expect(json_response[0]['tests'][1]['limits']).to eq '2-8'
+      expect(json_response[0]['tests'][1]['results']).to eq '5'
+    end
+
+    it 'retorna uma mensagem de erro caso o token não exista' do
+      patient = Patient.create(cpf: '283.368.670-66', full_name: 'Reginaldo Rossi', email: 'reidobrega@gmail.com',
+                               birth_date: '1944-02-14', address: '200 Rua do Garçom', city: 'Recife', state: 'PE')
+      doctor = Doctor.create(crm: 'B000BJ20J4', crm_state: 'PI', full_name: 'Dr. Ross Geller',
+                             email: 'wewereonabreak@gmail.com')
+      examination = Examination.create(patient_id: patient.id, doctor_id: doctor.id, result_token: 'SCCP10',
+                                       date: '2023-10-31')
+      Test.create(examination_id: examination.id, type: 'Hemácias', limits: '45-52', results: '97')
+      Test.create(examination_id: examination.id, type: 'Glóbulos Neutrônicos', limits: '2-8', results: '5')
+
+      get '/tests/batata'
+
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to include 'application/json'
+      json_response = JSON.parse(last_response.body)
+      expect(json_response.class).to eq Hash
+      expect(json_response['errors']['message']).to eq 'Não foi encontrado nenhum exame com o token informado.'
+    end
+
+    it 'retorna uma mensagem de erro caso a conexão com o banco de dados falhe' do
+      allow(DatabaseService).to receive(:connect).and_raise(PG::ConnectionBad)
+
+      get '/tests/olamundo'
+
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to include 'application/json'
+      json_response = JSON.parse(last_response.body)
+      expect(json_response.class).to eq Hash
+      expect(json_response['errors']['message']).to eq 'Não foi possível conectar-se ao banco de dados.'
     end
   end
 end

--- a/views/index.erb
+++ b/views/index.erb
@@ -11,7 +11,7 @@
     <br>
     <p id="alerts"></p>
     <form id="search-exams-form">
-        <label for="result-token">Código do Exame</label>
+        <label for="result-token">Token do exame</label>
         <input id="result-token" name="result-token" type="text" />
         <button id="search-exam-button" type="submit" class="btn normal-btn">Buscar</button>
     </form>

--- a/views/index.erb
+++ b/views/index.erb
@@ -7,12 +7,24 @@
     <title>Rebase Labs</title>
 </head>
 <body>
-    <section id="test-results">
-        <h2>Resultados dos Exames</h2>
+    <h2>Resultados dos Exames</h2>
+    <br>
+    <p id="alerts"></p>
+    <form id="search-exams-form">
+        <label for="result-token">Código do Exame</label>
+        <input id="result-token" name="result-token" type="text" />
+        <button id="search-exam-button" type="submit" class="btn normal-btn">Buscar</button>
+    </form>
+    <section id="search-exam-results-section" class="hidden">
+        <button id="back-to-list-button" class="btn normal-btn">Voltar para a lista</button>
+        <div id="search-exam-info"></div>
+        <div id="search-exam-test-results" class="table-div"></div>
+    </section>
+    <section id="list-exams-section">
         <div class="table-div">
-            <table id="test-results-table">
+            <table id="list-exams-table">
                 <thead>
-                    <tr id="table-headers">
+                    <tr id="list-exams-table-headers">
                         <th>Token do exame</th>
                         <th>Data do resultado</th>
                         <th>Nome completo</th>
@@ -24,19 +36,12 @@
                         <th>Nome do médico(a)</th>
                     </tr>
                 </thead>
-                <tbody id="tbody">
+                <tbody id="list-exams-tbody">
                 </tbody>
             </table>
         </div>
         <div id="pagination"></div>
     </section>
-    <script>
-        <% if ENV['APP_ENV'] == 'test' %>
-            const tests_url = 'http://127.0.0.1:4242/tests'
-        <% else %>
-            const tests_url = 'http://localhost:3000/tests'
-        <% end %>
-    </script>
     <script src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Issues resolvidas
- Resolve #11
- Resolve #12 

# Com essa PR, os seguintes objetivos são concluídos:
- [x] Implementar o endpoint `/tests/:result_token` que retorna os detalhes de um exame específico, buscado no banco de dados atravé de `result_token`;
- [x] No endpoint `/`, realizar uma requisição usando Fetch API para o endpoint `/tests/:result_token` através de um formulário HTML;
- [x] Exibe os resultados da pesquisa por um exame na própria rota `/`, de forma dinâmica apenas manipulando o DOM usando JavaScript puro;
- [x] Permite a transição entre as telas de listagem de todos exames/resultado de uma busca por exame específico de forma reativa;
- [x] Adiciona alertas flash para dar feedbacks ao usuários sobre os resultados de suas pesquisas;

![image](https://github.com/eliseuramos93/rebase-labs/assets/111306649/60ee82fb-c96d-46f2-af45-4727073d3fb6)

![image](https://github.com/eliseuramos93/rebase-labs/assets/111306649/5b9ba21a-a66f-4a01-8c76-7d852c66c0eb)

![image](https://github.com/eliseuramos93/rebase-labs/assets/111306649/47d4a758-68e0-4cda-8ff4-934cdb7f7228)

![image](https://github.com/eliseuramos93/rebase-labs/assets/111306649/32a82d53-9860-40eb-9bdc-a01c90f736d4)

![image](https://github.com/eliseuramos93/rebase-labs/assets/111306649/feb90ae6-59d7-44cf-99d0-f9e224542e2b)
(Essa tela ocorre caso o usuário faça uma pesquisa bem sucedida, e uma pesquisa por um exame que não existe)